### PR TITLE
[WiP] Swizzling to hijack UIResponder chain ... :| 

### DIFF
--- a/GridLock.xcodeproj/project.pbxproj
+++ b/GridLock.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		29C6CF85223C002B00FC321B /* GridLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 29C6CF77223C002A00FC321B /* GridLock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29C6CFD2223C0B9400FC321B /* GridLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C6CFD1223C0B9400FC321B /* GridLock.swift */; };
 		29C6CFD7223C0FD200FC321B /* GridLockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C6CFD6223C0FD200FC321B /* GridLockViewController.swift */; };
+		9A1DFDFE223D9BD700698B9D /* Swizzle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1DFDFD223D9BD700698B9D /* Swizzle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +34,7 @@
 		29C6CF84223C002B00FC321B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29C6CFD1223C0B9400FC321B /* GridLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridLock.swift; sourceTree = "<group>"; };
 		29C6CFD6223C0FD200FC321B /* GridLockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridLockViewController.swift; sourceTree = "<group>"; };
+		9A1DFDFD223D9BD700698B9D /* Swizzle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swizzle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 			children = (
 				29C6CFD1223C0B9400FC321B /* GridLock.swift */,
 				29C6CFD6223C0FD200FC321B /* GridLockViewController.swift */,
+				9A1DFDFD223D9BD700698B9D /* Swizzle.swift */,
 				29C6CFD0223C0B6C00FC321B /* Resources */,
 			);
 			path = GridLock;
@@ -209,6 +212,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A1DFDFE223D9BD700698B9D /* Swizzle.swift in Sources */,
 				29C6CFD2223C0B9400FC321B /* GridLock.swift in Sources */,
 				29C6CFD7223C0FD200FC321B /* GridLockViewController.swift in Sources */,
 			);

--- a/GridLock/GridLock.swift
+++ b/GridLock/GridLock.swift
@@ -9,21 +9,51 @@
 import Foundation
 
 public class GridLock {
+    public static var shared = GridLock()
     
-    var gridlockWindow: UIWindow?
-    let appDelegate: UIApplicationDelegate
-    
-    public init(appDelegate: UIApplicationDelegate, frame: CGRect) {
-        self.appDelegate = appDelegate
-        self.createGridLockWindow(frame: frame)
+    public var isActive = false {
+        didSet {
+            isActive ? activate() : deactivate()
+        }
     }
     
-    func createGridLockWindow(frame: CGRect) {
-        gridlockWindow = UIWindow(frame: frame)
-        gridlockWindow?.rootViewController = GridLockViewController()
-        gridlockWindow?.windowLevel = UIWindow.Level(.greatestFiniteMagnitude)
-        gridlockWindow?.makeKeyAndVisible()
-        gridlockWindow?.isUserInteractionEnabled = false
+    let controller = GridLockViewController()
+    
+    private let window: UIWindow
+    private var isConfigured: Bool = false
+    
+    private init() {
+        guard let applicationFrame = UIApplication.shared.windows.first?.frame else {
+            fatalError("Unabled to determine application frame")
+        }
+        
+        window = UIWindow(frame: applicationFrame)
+        window.rootViewController = controller
+        window.windowLevel = UIWindow.Level(.greatestFiniteMagnitude)
+        window.makeKeyAndVisible()
+        window.isUserInteractionEnabled = false
     }
     
+    /// Initlises GridLock
+    public func configure() {
+        assert(_isDebugAssertConfiguration(), "GridLock is intended for use during development builds only")
+        UIApplication.initialiseSwizzleMotionEvent
+        UIApplication.initialiseSwizzleTouchBeganEvent
+        UIApplication.initialiseSwizzleTouchMovedEvent
+        UIApplication.initialiseSwizzleTouchEndedEvent
+        isConfigured = true
+    }
+    
+    /// Activates GridLock - applies an faint white canvas over current view
+    public func activate() {
+        assert(isConfigured, "Configure must be called before activate()")
+        controller.activate()
+    }
+    
+    /// Deactivates GridLock and resets canvas
+    public func deactivate() {
+        assert(isConfigured, "Configure must be called before deactivate()")
+        controller.deactivate()
+    }
+
 }

--- a/GridLock/GridLockViewController.swift
+++ b/GridLock/GridLockViewController.swift
@@ -9,11 +9,47 @@
 import UIKit
 
 class GridLockViewController: UIViewController {
+    var markers: [UIView] = []
+    var drawingLine: UIView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+    
+    public func activate() {
+        view.backgroundColor = UIColor.white.withAlphaComponent(0.2)
+    }
+    
+    public func deactivate() {
+        markers.forEach { $0.removeFromSuperview() }
+        drawingLine = nil
+        view.backgroundColor = .clear
+    }
+    
+    public func touchStarted(_ touch: UITouch) {
+        view.backgroundColor = .clear
+        let loc = touch.location(in: view)
+        let targetFrame = CGRect(x: loc.x, y: 0, width: 2, height: self.view.frame.height)
         
-        self.view.backgroundColor = .clear
+        drawingLine = UIView(frame: targetFrame)
+        drawingLine?.backgroundColor = .green
+        drawingLine?.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Ensure GridLock still active
+        guard let line = drawingLine else { return }
+        view.addSubview(line)
+    }
+    
+    public func touchMoved(_ touch: UITouch) {
+        let loc = touch.location(in: view)
+        drawingLine?.frame.origin.x = loc.x
+    }
+    
+    public func touchEnded(_ touch: UITouch) {
+        guard let marker = drawingLine else { return }
+        markers.append(marker)
+        view.backgroundColor = UIColor.white.withAlphaComponent(0.2)
     }
     
 }

--- a/GridLock/Swizzle.swift
+++ b/GridLock/Swizzle.swift
@@ -1,0 +1,82 @@
+//
+//  Swizzle.swift
+//  GridLock
+//
+//  Created by Stevey Brown on 16/03/2019.
+//  Copyright © 2019 Instil. All rights reserved.
+//
+
+import Foundation
+
+private let swizzling: (AnyClass, Selector, Selector) -> () = { forClass, originalSelector, swizzledSelector in
+    let originalMethod = class_getInstanceMethod(forClass, originalSelector)
+    let swizzledMethod = class_getInstanceMethod(forClass, swizzledSelector)
+    method_exchangeImplementations(originalMethod!, swizzledMethod!)
+}
+
+extension UIApplication {
+    
+    static let initialiseSwizzleMotionEvent: Void = {
+        let originalSelector = #selector(motionBegan(_:with:))
+        let swizzledSelector = #selector(swizzledMotionBegan(_:with:))
+        swizzling(UIApplication.self, originalSelector, swizzledSelector)
+    }()
+    
+    static let initialiseSwizzleTouchBeganEvent: Void = {
+        let originalSelector = #selector(touchesBegan(_:with:))
+        let swizzledSelector = #selector(swizzledTouchesBegan(_:with:))
+        swizzling(UIApplication.self, originalSelector, swizzledSelector)
+    }()
+    
+    static let initialiseSwizzleTouchMovedEvent: Void = {
+        let originalSelector = #selector(touchesMoved(_:with:))
+        let swizzledSelector = #selector(swizzledTouchesMoved(_:with:))
+        swizzling(UIApplication.self, originalSelector, swizzledSelector)
+    }()
+    
+    static let initialiseSwizzleTouchEndedEvent: Void = {
+        let originalSelector = #selector(touchesEnded(_:with:))
+        let swizzledSelector = #selector(swizzledTouchesEnded(_:with:))
+        swizzling(UIApplication.self, originalSelector, swizzledSelector)
+    }()
+    
+    @objc func swizzledMotionBegan(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            GridLock.shared.isActive = !GridLock.shared.isActive
+        }
+        
+        // Run default implementation of Apps UIApplication
+        swizzledMotionBegan(motion, with: event)
+    }
+    
+    @objc func swizzledTouchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touchLocation = touches.first else { return }
+        
+        if GridLock.shared.isActive {
+            GridLock.shared.controller.touchStarted(touchLocation)
+        }
+        
+        //        swizzledTouchesBegan(touches, with: event)
+    }
+    
+    @objc func swizzledTouchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touchLocation = touches.first else { return }
+        
+        if GridLock.shared.isActive {
+            GridLock.shared.controller.touchMoved(touchLocation)
+        }
+        
+        //        swizzledTouchesBegan(touches, with: event)
+    }
+    
+    @objc func swizzledTouchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touchLocation = touches.first else { return }
+        
+        if GridLock.shared.isActive {
+            GridLock.shared.controller.touchEnded(touchLocation)
+        }
+        
+        //        swizzledTouchesEnded(touches, with: event)
+    }
+}
+

--- a/GridLockDemoApp/GridLockDemoApp/AppDelegate.swift
+++ b/GridLockDemoApp/GridLockDemoApp/AppDelegate.swift
@@ -11,13 +11,11 @@ import GridLock
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
-    var gridLock: GridLock?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        self.gridLock = GridLock(appDelegate: self, frame: window?.frame ?? .zero)
+        GridLock.shared.configure()
         return true
     }
 
@@ -42,7 +40,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }
 

--- a/GridLockDemoApp/GridLockDemoApp/ViewController.swift
+++ b/GridLockDemoApp/GridLockDemoApp/ViewController.swift
@@ -31,7 +31,6 @@ class ViewController: UIViewController {
     @objc func buttonPressed(sender: UIButton) {
         print("hello world")
     }
-
-
+    
 }
 


### PR DESCRIPTION
Using a second window doesn't seem to allow it to participate in the UIResponder chain. This adds swizzling to UIApplication and hijacks the UIResponder chain touch/motion events that reach the UIApplication. 

Still need to determine if there's a better approach to the swizzling :\ 